### PR TITLE
Performance improvements.

### DIFF
--- a/inst/include/mob/compat/views.h
+++ b/inst/include/mob/compat/views.h
@@ -23,22 +23,25 @@ private:
 template <cuda::std::ranges::range R>
   requires std::movable<R>
 struct owning_view : cuda::std::ranges::view_interface<owning_view<R>> {
-  owning_view(R &&range) : underlying(std::move(range)) {};
+  __device__ __host__ owning_view(R &&range) : underlying(std::move(range)) {};
+
+  owning_view(const owning_view &) = delete;
+  owning_view &operator=(const owning_view &) = delete;
 
   owning_view(owning_view &&) = default;
   owning_view &operator=(owning_view &&other) = default;
 
-  cuda::std::ranges::iterator_t<const R> begin() const {
-    return cuda::std::begin(underlying);
+  __device__ __host__ cuda::std::ranges::iterator_t<const R> begin() const {
+    return cuda::std::ranges::begin(underlying);
   }
-  cuda::std::ranges::iterator_t<const R> end() const {
-    return cuda::std::end(underlying);
+  __device__ __host__ cuda::std::ranges::sentinel_t<const R> end() const {
+    return cuda::std::ranges::end(underlying);
   }
-  cuda::std::ranges::iterator_t<R> begin() {
-    return cuda::std::begin(underlying);
+  __device__ __host__ cuda::std::ranges::iterator_t<R> begin() {
+    return cuda::std::ranges::begin(underlying);
   }
-  cuda::std::ranges::iterator_t<R> end() {
-    return cuda::std::end(underlying);
+  __device__ __host__ cuda::std::ranges::sentinel_t<R> end() {
+    return cuda::std::ranges::end(underlying);
   }
 
 private:

--- a/inst/include/mob/ds/partition.h
+++ b/inst/include/mob/ds/partition.h
@@ -27,7 +27,7 @@ struct partition {
   typename System::vector<uint32_t> partitions_offset_;
   typename System::vector<uint32_t> partitions_size_;
 
-  partition(std::vector<uint32_t> members) {
+  partition(thrust::host_vector<uint32_t> members) {
     uint32_t count = *std::max_element(members.begin(), members.end()) + 1;
 
     // TODO: some of this can be parallelized. Maybe not worth it if only done
@@ -37,16 +37,23 @@ struct partition {
       partitions[members[i]].push_back(i);
     }
 
-    partitions_data_.reserve(members.size());
-    partitions_size_.reserve(count);
-    partitions_offset_.reserve(count);
+    thrust::host_vector<uint32_t> partitions_data;
+    thrust::host_vector<uint32_t> partitions_offset;
+    thrust::host_vector<uint32_t> partitions_size;
+
+    partitions_data.reserve(members.size());
+    partitions_size.reserve(count);
+    partitions_offset.reserve(count);
     for (const std::vector<uint32_t> &p : partitions) {
-      partitions_offset_.push_back(partitions_data_.size());
-      partitions_size_.push_back(p.size());
-      partitions_data_.insert(partitions_data_.end(), p.begin(), p.end());
+      partitions_offset.push_back(partitions_data.size());
+      partitions_size.push_back(p.size());
+      partitions_data.insert(partitions_data.end(), p.begin(), p.end());
     }
 
     members_ = std::move(members);
+    partitions_data_ = std::move(partitions_data);
+    partitions_size_ = std::move(partitions_size);
+    partitions_offset_ = std::move(partitions_offset);
   }
 
   size_t partitions_count() const {

--- a/inst/include/mob/ds/span.h
+++ b/inst/include/mob/ds/span.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cuda/std/ranges>
 #include <dust/random/cuda_compatibility.hpp>
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>

--- a/inst/include/mob/intersection.h
+++ b/inst/include/mob/intersection.h
@@ -6,7 +6,7 @@
 namespace mob {
 
 template <cuda::std::ranges::input_range LeftRange,
-          cuda::std::ranges::input_range RightRange>
+          cuda::std::ranges::random_access_range RightRange>
   requires cuda::std::ranges::enable_view<LeftRange> &&
            cuda::std::ranges::enable_view<RightRange>
 struct intersection_view : cuda::std::ranges::view_interface<
@@ -24,7 +24,7 @@ struct intersection_view : cuda::std::ranges::view_interface<
       skip();
     }
 
-    __host__ __device__ iterator &operator++() {
+    __nv_exec_check_disable__ __host__ __device__ iterator &operator++() {
       ++left;
       skip();
       return *this;
@@ -34,20 +34,20 @@ struct intersection_view : cuda::std::ranges::view_interface<
       ++(*this);
     }
 
-    __host__ __device__ bool operator==(sentinel) const {
-      return left == left_end;
+    __nv_exec_check_disable__ __host__ __device__ bool
+    operator==(sentinel) const {
+      return left == left_end || right == right_end;
     }
 
-    __host__ __device__ reference operator*() const {
+    __nv_exec_check_disable__ __host__ __device__ reference operator*() const {
       return *left;
     }
 
   private:
-    __host__ __device__ void skip() {
+    __nv_exec_check_disable__ __host__ __device__ void skip() {
       for (; left != left_end; left++) {
         right = mob::compat::lower_bound(right, right_end, *left);
         if (right == right_end) {
-          left = left_end;
           break;
         } else if (*right == *left) {
           break;


### PR DESCRIPTION
- Filter out the household first, and then intersect with the susceptible set.
- Avoid non-trivial copies from host to device memory by making the infection process generic over the individual type.
- Add some missing moves.
- Avoid iterator-based copies from device_vector to Rcpp.
- Avoid element-wise initialization of device_vector.