### PR TITLE
Implement fast initialization of RNG states on the GPU.

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,12 +5,12 @@ random_create_device <- function(size, seed = NULL) {
     .Call(`_mob_random_create_device`, size, seed)
 }
 
-runif_device <- function(rngs, n, min, max) {
-    .Call(`_mob_runif_device`, rngs, n, min, max)
+random_uniform_device <- function(rngs, n, min, max) {
+    .Call(`_mob_random_uniform_device`, rngs, n, min, max)
 }
 
-rbinom_device <- function(rngs, n, size, prob) {
-    .Call(`_mob_rbinom_device`, rngs, n, size, prob)
+random_binomial_device <- function(rngs, n, size, prob) {
+    .Call(`_mob_random_binomial_device`, rngs, n, size, prob)
 }
 
 bernoulli_sampler_device <- function(data, p, seed = NULL) {
@@ -41,12 +41,12 @@ random_create_host <- function(size, seed = NULL) {
     .Call(`_mob_random_create_host`, size, seed)
 }
 
-runif_host <- function(rngs, n, min, max) {
-    .Call(`_mob_runif_host`, rngs, n, min, max)
+random_uniform_host <- function(rngs, n, min, max) {
+    .Call(`_mob_random_uniform_host`, rngs, n, min, max)
 }
 
-rbinom_host <- function(rngs, n, size, prob) {
-    .Call(`_mob_rbinom_host`, rngs, n, size, prob)
+random_binomial_host <- function(rngs, n, size, prob) {
+    .Call(`_mob_random_binomial_host`, rngs, n, size, prob)
 }
 
 homogeneous_infection_process_host <- function(rngs, susceptible, infected, infection_probability) {

--- a/R/mob.R
+++ b/R/mob.R
@@ -9,6 +9,9 @@ selection_sampler <- create_wrapper("selection_sampler")
 betabinomial_sampler <- create_wrapper("betabinomial_sampler")
 bernoulli_sampler <- create_wrapper("bernoulli_sampler")
 
+random_uniform <- create_wrapper("random_uniform")
+random_binomial <- create_wrapper("random_binomial")
+
 random_create <- create_wrapper("random_create")
 partition_create <- create_wrapper("partition_create")
 homogeneous_infection_process <- create_wrapper("homogeneous_infection_process")

--- a/inst/include/mob/parallel_random.h
+++ b/inst/include/mob/parallel_random.h
@@ -2,12 +2,90 @@
 
 #include <mob/random.h>
 
+#include <cuda/std/array>
 #include <dust/random/prng.hpp>
 #include <dust/random/xoroshiro128.hpp>
 #include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
 #include <thrust/host_vector.h>
 
 namespace mob {
+
+// For a generator with period 2^N, this table contains the jump polynomials for
+// 2^(N/2) up to 2^(N/2+31).
+//
+// The numbers were generated using https://github.com/nessan/xoshiro and
+// https://gist.github.com/plietar/ab99d2a6fec65dc20a438c712a8a703b
+constexpr __device__ __host__
+    cuda::std::array<cuda::std::array<uint64_t, 2>, 32>
+        xoroshiro128plus_jump_table = {{
+            {0xdf900294d8f554a5, 0x170865df4b3201fc},
+            {0x2992ead4972eaed2, 0xb2a7b279a8cb1f50},
+            {0xc026a7d9e04a7700, 0xe7859c665be57882},
+            {0xb4cb6197dea2b1fe, 0x4b4a7aa8c389701c},
+            {0x0dcfc5b909e7df4d, 0xadb7753d55646eef},
+            {0x468431669864f789, 0xc80926301806a352},
+            {0x22b6c1736285fcc8, 0xc05da051ec96af1d},
+            {0x74c1daac8729d8bb, 0xf88f6bac8fd30448},
+            {0x847757c126b23e45, 0x752b98d002c408f7},
+            {0x0f9eaa62d0c9e2a3, 0x1aa7bc96dbace110},
+            {0x7475d71b98314377, 0xc469b29353a4984b},
+            {0xbbb7d266d61c85ea, 0x4b6dd41bce3bb499},
+            {0xc419b3742570e16f, 0xe023777e70b3a2f8},
+            {0x2a71db3a3ce8b968, 0x131e94fb35203d80},
+            {0x2897bb8961b4dce9, 0x9240c95b1e7fa08b},
+            {0xf0fc3553d7881d5f, 0xb879fca0915f893f},
+            {0xe754db3fbc7536bc, 0x2adca86fbefe1366},
+            {0x0a9e201adfe7baa9, 0x0a40a688d77855ba},
+            {0x1d0d601e49c35837, 0x17771c905e0775a8},
+            {0x9b031395aec7b584, 0x2cf775e419a607e0},
+            {0x79ead2eeddf66699, 0x93a7cf27dec9b306},
+            {0xe1b9805c107679fc, 0x93615189fe85b7d5},
+            {0x2c3925dcd790e3d6, 0x466421124b50fbfb},
+            {0xdca9b0fa4e95600e, 0x1cda7bd04e3bb94b},
+            {0xefc7905e1cbb5ffb, 0x5ec431d73bbfe49f},
+            {0x854414811d534483, 0x31a1f85fd532f302},
+            {0xadb9ba2958f30b6e, 0xed9b991c09177e2f},
+            {0x76f8fdf26b0d1cbb, 0x38d9e87dffdfca70},
+            {0x51f21cddcebdb8c7, 0xd8e9e7254052af4d},
+            {0xa03f796efb295305, 0x62769780d13fbc08},
+        }};
+
+// This comes from dust, but isn't marked as __device__ there
+template <typename T>
+__host__ __device__ void
+jump_polynomial(T &state,
+                cuda::std::array<typename T::int_type, T::size()> coef) {
+  using int_type = typename T::int_type;
+  constexpr auto N = T::size();
+  int_type work[N] = {};                     // enforced zero-initialisation
+  constexpr int bits = sizeof(int_type) * 8; // bit_size<int_type>();
+  for (size_t i = 0; i < N; ++i) {
+    for (int b = 0; b < bits; b++) {
+      if (coef[i] & static_cast<int_type>(1) << b) {
+        for (size_t j = 0; j < N; ++j) {
+          work[j] ^= state[j];
+        }
+      }
+      next(state);
+    }
+  }
+  for (size_t i = 0; i < N; ++i) {
+    state[i] = work[i];
+  }
+}
+
+/**
+ * Perform the equivalent of n jump calls.
+ */
+__host__ __device__ void jump_n(dust::random::xoroshiro128plus &rng,
+                                uint32_t n) {
+  for (size_t i = 0; i < 32; i++) {
+    if (n & static_cast<size_t>(1) << i) {
+      jump_polynomial(rng, xoroshiro128plus_jump_table[i]);
+    }
+  }
+}
 
 /**
  * A container for dust random states, optimized for GPU programming.
@@ -43,31 +121,57 @@ template <template <typename> typename Vector,
           random_state_storage T = dust::random::xoroshiro128plus>
 struct parallel_random {
   using rng_state = T;
-  using vector_type = Vector<typename rng_state::int_type>;
+  using int_type = typename rng_state::int_type;
+  using vector_type = Vector<int_type>;
 
   static constexpr size_t width = rng_state::size();
 
-  parallel_random(size_t size, int seed = 0) : size_(size) {
-    dust::random::prng<rng_state> states(size, seed);
+  parallel_random(size_t size, int seed = 0)
+      : size_(size), data_(size * width) {
+    auto initial = dust::random::seed<rng_state>(seed);
 
-    // We first build the interleaved array on the CPU and then copy it to GPU
-    // memory as a single memcpy. This is much faster than initializing those
-    // states one by one.
-    //
-    // TODO: use something like cudamemcpy2d, which should be able to directly
-    // do strided copies. Alternatively, do this directly on the GPU, using
-    // longer jumps.
-    thrust::host_vector<typename rng_state::int_type> data(size * width);
-    for (size_t i = 0; i < size; i++) {
-      rng_state rng = states.state(i);
-      for (size_t j = 0; j < width; j++) {
-        data[i + j * size] = rng.state[j];
-      }
+    populate(initial, thrust::iterator_system_t<iterator>{});
+  }
+
+  void populate(rng_state state, thrust::host_system_tag) {
+    for (auto it = begin(); it != end(); it++) {
+      (*it).put(state);
+      dust::random::jump(state);
+    }
+  }
+
+  // When running on the GPU, each state is initialized independently and
+  // concurrently. It uses the offset of each state `n` as the argument to
+  // `jump_n`. `jump_n` is implemented by doing repeated 2^k sized jumps, where
+  // k are the set bits of `n`.
+  //
+  // There is some amount of repeated work here among the different threads,
+  // which is fine since it is parallelized but could be improved by sharing
+  // the initial computations, especially when size >>> number of concurrent
+  // GPU threads. I cannot find a suitable abstraction in thrust, nor can I
+  // figure out what it should be called. This is similar, but not quite the
+  // same, as a prefix sum. Or possibly some kind of tree traversal.
+  void populate(const rng_state &initial, thrust::device_system_tag) {
+    if (size_ >= std::numeric_limits<uint32_t>::max()) {
+      throw std::logic_error("Maximum size is 32 bits");
     }
 
-    // This is constant time if data_ is actually host memory, or a single
-    // memcpy if on the GPU.
-    data_ = std::move(data);
+    // Serialize the initial state so it can be captured onto the GPU more
+    // easily.
+    cuda::std::array<int_type, width> initial_data;
+    std::copy_n(initial.state, width, initial_data.begin());
+
+    iterator output = begin();
+    thrust::for_each(thrust::device, thrust::counting_iterator<size_t>(0),
+                     thrust::counting_iterator<size_t>(size_),
+                     [=] __device__(size_t n) {
+                       rng_state state;
+                       for (size_t i = 0; i < width; i++) {
+                         state.state[i] = initial_data[i];
+                       }
+                       jump_n(state, n);
+                       output[n].put(state);
+                     });
   }
 
   struct proxy;

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -23,9 +23,9 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// runif_device
-inline Rcpp::NumericVector runif_device(Rcpp::XPtr<mob::system::device::random> rngs, size_t n, double min, double max);
-RcppExport SEXP _mob_runif_device(SEXP rngsSEXP, SEXP nSEXP, SEXP minSEXP, SEXP maxSEXP) {
+// random_uniform_device
+inline Rcpp::NumericVector random_uniform_device(Rcpp::XPtr<mob::system::device::random> rngs, size_t n, double min, double max);
+RcppExport SEXP _mob_random_uniform_device(SEXP rngsSEXP, SEXP nSEXP, SEXP minSEXP, SEXP maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -33,13 +33,13 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< size_t >::type n(nSEXP);
     Rcpp::traits::input_parameter< double >::type min(minSEXP);
     Rcpp::traits::input_parameter< double >::type max(maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(runif_device(rngs, n, min, max));
+    rcpp_result_gen = Rcpp::wrap(random_uniform_device(rngs, n, min, max));
     return rcpp_result_gen;
 END_RCPP
 }
-// rbinom_device
-inline Rcpp::NumericVector rbinom_device(Rcpp::XPtr<mob::system::device::random> rngs, size_t n, size_t size, double prob);
-RcppExport SEXP _mob_rbinom_device(SEXP rngsSEXP, SEXP nSEXP, SEXP sizeSEXP, SEXP probSEXP) {
+// random_binomial_device
+inline Rcpp::NumericVector random_binomial_device(Rcpp::XPtr<mob::system::device::random> rngs, size_t n, size_t size, double prob);
+RcppExport SEXP _mob_random_binomial_device(SEXP rngsSEXP, SEXP nSEXP, SEXP sizeSEXP, SEXP probSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -47,7 +47,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< size_t >::type n(nSEXP);
     Rcpp::traits::input_parameter< size_t >::type size(sizeSEXP);
     Rcpp::traits::input_parameter< double >::type prob(probSEXP);
-    rcpp_result_gen = Rcpp::wrap(rbinom_device(rngs, n, size, prob));
+    rcpp_result_gen = Rcpp::wrap(random_binomial_device(rngs, n, size, prob));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -142,9 +142,9 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// runif_host
-inline Rcpp::NumericVector runif_host(Rcpp::XPtr<mob::system::host::random> rngs, size_t n, double min, double max);
-RcppExport SEXP _mob_runif_host(SEXP rngsSEXP, SEXP nSEXP, SEXP minSEXP, SEXP maxSEXP) {
+// random_uniform_host
+inline Rcpp::NumericVector random_uniform_host(Rcpp::XPtr<mob::system::host::random> rngs, size_t n, double min, double max);
+RcppExport SEXP _mob_random_uniform_host(SEXP rngsSEXP, SEXP nSEXP, SEXP minSEXP, SEXP maxSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -152,13 +152,13 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< size_t >::type n(nSEXP);
     Rcpp::traits::input_parameter< double >::type min(minSEXP);
     Rcpp::traits::input_parameter< double >::type max(maxSEXP);
-    rcpp_result_gen = Rcpp::wrap(runif_host(rngs, n, min, max));
+    rcpp_result_gen = Rcpp::wrap(random_uniform_host(rngs, n, min, max));
     return rcpp_result_gen;
 END_RCPP
 }
-// rbinom_host
-inline Rcpp::NumericVector rbinom_host(Rcpp::XPtr<mob::system::host::random> rngs, size_t n, size_t size, double prob);
-RcppExport SEXP _mob_rbinom_host(SEXP rngsSEXP, SEXP nSEXP, SEXP sizeSEXP, SEXP probSEXP) {
+// random_binomial_host
+inline Rcpp::NumericVector random_binomial_host(Rcpp::XPtr<mob::system::host::random> rngs, size_t n, size_t size, double prob);
+RcppExport SEXP _mob_random_binomial_host(SEXP rngsSEXP, SEXP nSEXP, SEXP sizeSEXP, SEXP probSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -166,7 +166,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< size_t >::type n(nSEXP);
     Rcpp::traits::input_parameter< size_t >::type size(sizeSEXP);
     Rcpp::traits::input_parameter< double >::type prob(probSEXP);
-    rcpp_result_gen = Rcpp::wrap(rbinom_host(rngs, n, size, prob));
+    rcpp_result_gen = Rcpp::wrap(random_binomial_host(rngs, n, size, prob));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -264,8 +264,8 @@ END_RCPP
 
 static const R_CallMethodDef CallEntries[] = {
     {"_mob_random_create_device", (DL_FUNC) &_mob_random_create_device, 2},
-    {"_mob_runif_device", (DL_FUNC) &_mob_runif_device, 4},
-    {"_mob_rbinom_device", (DL_FUNC) &_mob_rbinom_device, 4},
+    {"_mob_random_uniform_device", (DL_FUNC) &_mob_random_uniform_device, 4},
+    {"_mob_random_binomial_device", (DL_FUNC) &_mob_random_binomial_device, 4},
     {"_mob_bernoulli_sampler_device", (DL_FUNC) &_mob_bernoulli_sampler_device, 3},
     {"_mob_homogeneous_infection_process_device", (DL_FUNC) &_mob_homogeneous_infection_process_device, 4},
     {"_mob_partition_create_device", (DL_FUNC) &_mob_partition_create_device, 1},
@@ -273,8 +273,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_mob_selection_sampler_device", (DL_FUNC) &_mob_selection_sampler_device, 3},
     {"_mob_betabinomial_sampler_device", (DL_FUNC) &_mob_betabinomial_sampler_device, 3},
     {"_mob_random_create_host", (DL_FUNC) &_mob_random_create_host, 2},
-    {"_mob_runif_host", (DL_FUNC) &_mob_runif_host, 4},
-    {"_mob_rbinom_host", (DL_FUNC) &_mob_rbinom_host, 4},
+    {"_mob_random_uniform_host", (DL_FUNC) &_mob_random_uniform_host, 4},
+    {"_mob_random_binomial_host", (DL_FUNC) &_mob_random_binomial_host, 4},
     {"_mob_homogeneous_infection_process_host", (DL_FUNC) &_mob_homogeneous_infection_process_host, 4},
     {"_mob_partition_create_host", (DL_FUNC) &_mob_partition_create_host, 1},
     {"_mob_household_infection_process_host", (DL_FUNC) &_mob_household_infection_process_host, 5},

--- a/src/mob_types.h
+++ b/src/mob_types.h
@@ -27,16 +27,16 @@ random_create_device(size_t size,
 
 // [[Rcpp::export]]
 inline Rcpp::NumericVector
-runif_device(Rcpp::XPtr<mob::system::device::random> rngs, size_t n, double min,
-             double max) {
-  return runif_wrapper<mob::system::device>(rngs, n, min, max);
+random_uniform_device(Rcpp::XPtr<mob::system::device::random> rngs, size_t n,
+                      double min, double max) {
+  return random_uniform_wrapper<mob::system::device>(rngs, n, min, max);
 }
 
 // [[Rcpp::export]]
 inline Rcpp::NumericVector
-rbinom_device(Rcpp::XPtr<mob::system::device::random> rngs, size_t n,
-              size_t size, double prob) {
-  return rbinom_wrapper<mob::system::device>(rngs, n, size, prob);
+random_binomial_device(Rcpp::XPtr<mob::system::device::random> rngs, size_t n,
+                       size_t size, double prob) {
+  return random_binomial_wrapper<mob::system::device>(rngs, n, size, prob);
 }
 
 // [[Rcpp::export]]
@@ -96,16 +96,16 @@ random_create_host(size_t size,
 
 // [[Rcpp::export]]
 inline Rcpp::NumericVector
-runif_host(Rcpp::XPtr<mob::system::host::random> rngs, size_t n, double min,
-           double max) {
-  return runif_wrapper<mob::system::host>(rngs, n, min, max);
+random_uniform_host(Rcpp::XPtr<mob::system::host::random> rngs, size_t n,
+                    double min, double max) {
+  return random_uniform_wrapper<mob::system::host>(rngs, n, min, max);
 }
 
 // [[Rcpp::export]]
 inline Rcpp::NumericVector
-rbinom_host(Rcpp::XPtr<mob::system::host::random> rngs, size_t n, size_t size,
-            double prob) {
-  return rbinom_wrapper<mob::system::host>(rngs, n, size, prob);
+random_binomial_host(Rcpp::XPtr<mob::system::host::random> rngs, size_t n,
+                     size_t size, double prob) {
+  return random_binomial_wrapper<mob::system::host>(rngs, n, size, prob);
 }
 
 // [[Rcpp::export]]

--- a/src/random_wrapper.h
+++ b/src/random_wrapper.h
@@ -22,31 +22,35 @@ random_create_wrapper(size_t size, Rcpp::Nullable<Rcpp::NumericVector> seed) {
 }
 
 template <typename System>
-Rcpp::NumericVector runif_wrapper(Rcpp::XPtr<typename System::random> rngs,
-                                  size_t n, double min, double max) {
+Rcpp::NumericVector
+random_uniform_wrapper(Rcpp::XPtr<typename System::random> rngs, size_t n,
+                       double min, double max) {
   if (rngs->size() < n) {
     Rcpp::stop("RNG state is too small: %d < %d", rngs->size(), n);
   }
 
   typename System::vector<double> result(n);
-  thrust::transform(rngs->begin(), rngs->end(), result.begin(),
-                    [min, max] __device__(auto &rng) {
-                      return dust::random::uniform<double>(rng, min, max);
-                    });
+  thrust::transform(
+      rngs->begin(), rngs->begin() + n, result.begin(),
+      [min, max] __host__ __device__(typename System::random::proxy rng) {
+        return dust::random::uniform<double>(rng, min, max);
+      });
 
   return {result.begin(), result.end()};
 }
 
 template <typename System>
-Rcpp::NumericVector rbinom_wrapper(Rcpp::XPtr<typename System::random> rngs,
-                                   size_t n, size_t size, double prob) {
+Rcpp::NumericVector
+random_binomial_wrapper(Rcpp::XPtr<typename System::random> rngs, size_t n,
+                        size_t size, double prob) {
   if (rngs->size() < n) {
     Rcpp::stop("RNG state is too small: %d < %d", rngs->size(), n);
   }
 
   typename System::vector<double> result(n);
-  thrust::transform(rngs->begin(), rngs->end(), result.begin(),
-                    [size, prob] __device__(auto &rng) -> double {
+  thrust::transform(rngs->begin(), rngs->begin() + n, result.begin(),
+                    [size, prob] __host__ __device__(
+                        typename System::random::proxy rng) -> double {
                       return dust::random::binomial<double>(rng, size, prob);
                     });
 

--- a/tests/testthat/test-random.R
+++ b/tests/testthat/test-random.R
@@ -1,0 +1,27 @@
+mob_test("random_uniform returns a vector of the right size", {
+  rngs <- mob:::random_create(1000)
+  expect_length(mob:::random_uniform(rngs, 10, 0, 1), 10)
+  expect_length(mob:::random_uniform(rngs, 100, 0, 1), 100)
+  expect_length(mob:::random_uniform(rngs, 1000, 0, 1), 1000)
+  expect_error(mob:::random_uniform(rngs, 10000, 0, 1), "RNG state is too small")
+})
+
+test_that("host and system produce identical numbers", {
+  skip_on_ci() # No CUDA on CI
+
+  size <- 1e4
+  seed <- sample.int(1e9, 1)
+  host_values <- withr::with_options(list(mob.system = "host"), {
+    rngs <- mob:::random_create(size, seed)
+    mob:::random_uniform(rngs, size, min = 0, max = 0)
+  })
+
+  device_values <- withr::with_options(list(mob.system = "device"), {
+    rngs <- mob:::random_create(size, seed)
+    mob:::random_uniform(rngs, size, min = 0, max = 0)
+  })
+
+  expect_length(host_values, size)
+  expect_length(device_values, size)
+  expect_equal(host_values, device_values)
+})


### PR DESCRIPTION
By using different polynomials, we can update the xoroshiro generator as if we'd performed 2, 4, 8, ... jumps. This in allows us to perform arbitrarily sized jumps using log2(n) smaller jumps.

This is used to initialize the rng states directly on the GPU and concurrently, which is much faster than initializing them sequentially and then copying the state onto the CPU.